### PR TITLE
Cleaned up formatting, fixed test and added a timestamp parameter

### DIFF
--- a/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/dhcpdump/BasicDHCPDumpParser.java
+++ b/metron-platform/metron-parsers/src/main/java/org/apache/metron/parsers/dhcpdump/BasicDHCPDumpParser.java
@@ -34,132 +34,134 @@ import java.util.regex.Pattern;
 
 public class BasicDHCPDumpParser  extends BasicParser {
 
-    protected static final Logger LOG = LoggerFactory.getLogger(BasicDHCPDumpParser.class);
+  protected static final Logger LOG = LoggerFactory.getLogger(BasicDHCPDumpParser.class);
 
-    public static final String TIMESTAMP_PATTERN = "yyyy-MM-dd HH:mm:ss.SSS";
+  public static final String TIMESTAMP_PATTERN = "yyyy-MM-dd HH:mm:ss.SSS";
 
-    @Override
-    public void configure(Map<String, Object> config) {
+  public static final String TIMESTAMP_CONFIG = "timestamp_pattern";
+  private SimpleDateFormat timestampFormat = new SimpleDateFormat(TIMESTAMP_PATTERN);
 
-    }
 
-    @Override
-    public void init() {
+  @Override
+  public void configure(Map<String, Object> config) {
+    timestampFormat = new SimpleDateFormat((String) config.getOrDefault(TIMESTAMP_CONFIG, TIMESTAMP_PATTERN));
+  }
 
-    }
+  @Override
+  public void init() {
 
-    @Override
-    public List<JSONObject> parse(byte[] rawMessage) {
-        LOG.trace("[Metron] Starting to parse incoming message");
+  }
 
-        String decodedMessage = null;
-        JSONObject jsonMessage;
-        List<JSONObject> messages = new ArrayList<>();
+  @Override
+  public List<JSONObject> parse(byte[] rawMessage) {
+    LOG.trace("[Metron] Starting to parse incoming message");
 
+    String decodedMessage = null;
+    JSONObject jsonMessage;
+    List<JSONObject> messages = new ArrayList<>();
+
+    try {
+      decodedMessage = new String(rawMessage, "UTF-8");
+      LOG.trace("[Metron] Received message: " + decodedMessage);
+
+      String[] multiLineEvent = convertToMultiLine(decodedMessage);
+
+      jsonMessage = convertToKeyValue(multiLineEvent);
+
+      jsonMessage.put(Constants.Fields.ORIGINAL.getName(), decodedMessage);
+      if (jsonMessage.containsKey("time")) {
         try {
-            decodedMessage = new String(rawMessage, "UTF-8");
-            LOG.trace("[Metron] Received message: " + decodedMessage);
+          // convert timestamp to milli since epoch
+          long timestamp = timestampToEpoch((String) jsonMessage.get("time"));
+          jsonMessage.put(Constants.Fields.TIMESTAMP.getName(), timestamp);
+        } catch (java.text.ParseException e) {
+          LOG.warn(String.format("[Metron] Timestamp format mismatch %s, is invalid: %s", timestampFormat.toPattern(), jsonMessage.get("timestamp")));
+          jsonMessage.put(Constants.Fields.TIMESTAMP.getName(), System.currentTimeMillis());
+        }
+      } else {
+        LOG.warn(String.format("[Metron] Timestamp is missing: %s", jsonMessage));
+        jsonMessage.put(Constants.Fields.TIMESTAMP.getName(), System.currentTimeMillis());
+      }
 
-            String[] multiLineEvent = convertToMultiLine(decodedMessage);
+    } catch (RuntimeException e) {
+      LOG.error(e.getMessage(), e);
+      throw new RuntimeException(e.getMessage(), e);
+    } catch (Exception e) {
+      String message = "Unable to parse Message: " + decodedMessage;
+      LOG.error(message, e);
+      throw new IllegalStateException(message, e);
+    }
 
-            jsonMessage = convertToKeyValue(multiLineEvent);
+    messages.add(jsonMessage);
+    return messages;
+  }
 
-            jsonMessage.put(Constants.Fields.ORIGINAL.getName(), decodedMessage);
 
-            if (jsonMessage.containsKey("time")) {
-                try {
-                    // convert timestamp to milli since epoch
-                    long timestamp = timstampToEpoch((String) jsonMessage.get("time"), TIMESTAMP_PATTERN);
-                    jsonMessage.put(Constants.Fields.TIMESTAMP.getName(), timestamp);
-                } catch (java.text.ParseException e) {
-                    LOG.error(String.format("[Metron] Timestamp format mismatch %s, is invalid: %s", TIMESTAMP_PATTERN, jsonMessage.get("timestamp")));
-                    jsonMessage.put(Constants.Fields.TIMESTAMP.getName(), System.currentTimeMillis());
-                }
-            } else {
-                LOG.error(String.format("[Metron] Timestamp is missing: %s", jsonMessage));
-                jsonMessage.put(Constants.Fields.TIMESTAMP.getName(), System.currentTimeMillis());
-            }
+  private String[] convertToMultiLine(String msg) {
 
-        } catch (RuntimeException e) {
-            LOG.error(e.getMessage(), e);
-            throw new RuntimeException(e.getMessage(), e);
-        } catch (Exception e) {
-            String message = "Unable to parse Message: " + decodedMessage;
-            LOG.error(message, e);
-            throw new IllegalStateException(message, e);
+    msg = msg.replace("||", "");
+
+    int count = StringUtils.countMatches(msg, "|");
+
+    /* TODO find better method to prevent splitting the IP: field content,currently this works only when IP: is the last field in the event */
+    String[] multiLineEvent = msg.split(Pattern.quote("|"), count);
+
+    return multiLineEvent;
+  }
+
+  private JSONObject convertToKeyValue(String[] multiLineEvent) {
+    JSONObject keyValueEvent = new JSONObject();
+
+    for (String s: multiLineEvent) {
+      if (s.startsWith("TIME:")) {
+        keyValueEvent.put("time", s.split(":", 2)[1].trim());
+      } else if (s.startsWith("IP:")) {
+        String value = s.split(":", 2)[1];
+        value = value.replace("|", ">");
+
+        String[] values = value.split(">");
+
+        keyValueEvent.put(Constants.Fields.SRC_ADDR.getName(), values[0].trim());
+        keyValueEvent.put(Constants.Fields.DST_ADDR.getName(), values[1].trim());
+        keyValueEvent.put("mac_src_addr", values[2].trim());
+        keyValueEvent.put("mac_dst_addr", values[3].trim());
+      } else if (s.startsWith("OP:")) {
+        keyValueEvent.put("op", s.split(":")[1].split(" ")[1].trim());
+      } else if (s.startsWith("CIADDR:")) {
+        keyValueEvent.put("ciaddr", s.split(":", 2)[1].trim());
+      } else if (s.startsWith("YIADDR:")) {
+        keyValueEvent.put("yiaddr", s.split(":", 2)[1].trim());
+      } else if (s.startsWith("SIADDR:")) {
+        keyValueEvent.put("siaddr", s.split(":", 2)[1].trim());
+      } else if (s.startsWith("GIADDR:")) {
+        keyValueEvent.put("giaddr", s.split(":", 2)[1].trim());
+      } else if (s.startsWith("OPTION:")) {
+        /**
+         * Input examples
+         * OPTION:  12   5 Host name: A1244
+         * OPTION:  61   7 Client-identifier: 01:fc:f8:ae:e8:ef:db
+         */
+        Integer op = Integer.valueOf(s.split(":")[1].trim().split(" ")[0]);
+
+        Integer[] validOptions = {12, 61};
+
+        if (Arrays.asList(validOptions).contains(op)) {
+          if (op == 12) {
+            keyValueEvent.put("host_name", s.split(":", 3)[2].trim());
+          } else if (op == 61) {
+            keyValueEvent.put("client_identifier", s.split(":", 3)[2].trim());
+          }
         }
 
-        messages.add(jsonMessage);
-        return messages;
+      }
     }
 
-
-    private String[] convertToMultiLine(String msg) {
-
-        msg = msg.replace("||", "");
-
-        int count = StringUtils.countMatches(msg, "|");
-
-        /* TODO find better method to prevent splitting the IP: field content,currently this works only when IP: is the last field in the event */
-        String[] multiLineEvent = msg.split(Pattern.quote("|"), count);
-
-        return multiLineEvent;
-    }
-
-    private JSONObject convertToKeyValue(String[] multiLineEvent) {
-        JSONObject keyValueEvent = new JSONObject();
-
-        for (String s: multiLineEvent) {
-            if (s.startsWith("TIME:")) {
-                keyValueEvent.put("time", s.split(":", 2)[1].trim());
-            } else if (s.startsWith("IP:")) {
-                String value = s.split(":", 2)[1];
-                value = value.replace("|", ">");
-
-                String[] values = value.split(">");
-
-                keyValueEvent.put(Constants.Fields.SRC_ADDR.getName(), values[0].trim());
-                keyValueEvent.put(Constants.Fields.DST_ADDR.getName(), values[1].trim());
-                keyValueEvent.put("mac_src_addr", values[2].trim());
-                keyValueEvent.put("mac_dst_addr", values[3].trim());
-            } else if (s.startsWith("OP:")) {
-                keyValueEvent.put("op", s.split(":")[1].split(" ")[1].trim());
-            } else if (s.startsWith("CIADDR:")) {
-                keyValueEvent.put("ciaddr", s.split(":", 2)[1].trim());
-            } else if (s.startsWith("YIADDR:")) {
-                keyValueEvent.put("yiaddr", s.split(":", 2)[1].trim());
-            } else if (s.startsWith("SIADDR:")) {
-                keyValueEvent.put("siaddr", s.split(":", 2)[1].trim());
-            } else if (s.startsWith("GIADDR:")) {
-                keyValueEvent.put("giaddr", s.split(":", 2)[1].trim());
-            } else if (s.startsWith("OPTION:")) {
-                /**
-                 * Input examples
-                 * OPTION:  12   5 Host name: A1244
-                 * OPTION:  61   7 Client-identifier: 01:fc:f8:ae:e8:ef:db
-                 */
-                Integer op = Integer.valueOf(s.split(":")[1].trim().split(" ")[0]);
-
-                Integer[] validOptions = {12, 61};
-
-                if (Arrays.asList(validOptions).contains(op)) {
-                    if (op == 12) {
-                        keyValueEvent.put("host_name", s.split(":", 3)[2].trim());
-                    } else if (op == 61) {
-                        keyValueEvent.put("client_identifier", s.split(":", 3)[2].trim());
-                    }
-                }
-
-            }
-        }
-
-        return keyValueEvent;
-    }
+    return keyValueEvent;
+  }
 
 
-    private long timstampToEpoch(String timestamp, String datePattern) throws java.text.ParseException {
-        SimpleDateFormat dateFormat = new SimpleDateFormat(datePattern);
-        return dateFormat.parse(timestamp).getTime();
-    }
+  private long timestampToEpoch(String timestamp) throws java.text.ParseException {
+    return timestampFormat.parse(timestamp).getTime();
+  }
 
 }

--- a/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/dhcpdump/BasicDHCPDumpParserTest.java
+++ b/metron-platform/metron-parsers/src/test/java/org/apache/metron/parsers/dhcpdump/BasicDHCPDumpParserTest.java
@@ -25,6 +25,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 
 public class BasicDHCPDumpParserTest extends TestCase {
 
@@ -43,13 +44,13 @@ public class BasicDHCPDumpParserTest extends TestCase {
     }
 
     @Test
-    public void testSimpleMessage() throws ParseException, IOException {
+    public void testSimpleMessage() throws ParseException, IOException, java.text.ParseException {
         String rawMessage = "TIME: 2017-01-16 17:39:36.581|INTERFACE: eth2|OP:1 BOOTPREQUEST|CIADDR: 172.20.75.77|YIADDR: 0.0.0.0|SIADDR: 0.0.0.0|GIADDR: 172.20.75.8|CHADDR: fc:f8:ae:e8:ef:db:00:00:00:00:00:00:00:00:00:00|OPTION:  53   1 DHCP message type: 8 |DHCPINFORM|OPTION:  61   7 Client-identifier: 01:fc:f8:ae:e8:ef:db|OPTION:  12   5 Host name: A1244|OPTION:  60   8 Vendor class identifier: MSFT 5.0|OPTION:  55  13 Parameter Request List:   1 (Subnet mask)|| 15 (Domainname)||  3 (Routers)||  6 (DNS server)|| 44 (NetBIOS name server)|| 46 (NetBIOS node type)|| 47 (NetBIOS scope)|| 31 (Perform router discovery)|| 33 (Static route)||121 (Classless Static Route)||249 (MSFT - Classless route)|| 43 (Vendor specific info)||252 (MSFT - WinSock Proxy Auto Detect)|||IP: 100.100.100.177 > 172.20.1.11 | b8:ca:3a:67:95:8a > 0:50:56:84:68:43";
 
         JSONObject metronJSONObject = DHCPDumpParser.parse(rawMessage.getBytes()).get(0);
 
         Assert.assertEquals(metronJSONObject.get("original_string").toString(), rawMessage);
-        Assert.assertTrue((long) metronJSONObject.get("timestamp") == 1484584776581L);
+        Assert.assertEquals(new SimpleDateFormat(BasicDHCPDumpParser.TIMESTAMP_PATTERN).parse(metronJSONObject.get("time").toString()).getTime(), (long) metronJSONObject.get("timestamp"));
 
         Assert.assertEquals(metronJSONObject.get("ip_src_addr").toString(), "100.100.100.177");
         Assert.assertEquals(metronJSONObject.get("ip_dst_addr").toString(), "172.20.1.11");


### PR DESCRIPTION
I made enough changes that I thought it best to just submit a PR against your branch.  Changes include:
* Changed formatting to be 2 spaces instead of 4
* Added a "timestamp_format" field, so you can pass it in via the parser config and have it used for the timestamp format
* Adjusted the test to not have a timezone issue (your hardcoded epochmillis was presuming a timezone, so the test failed outside of that timezone).

One thing that I'd like to see is a unit test that exercises the todo:
`TODO find better method to prevent splitting the IP: field content,currently this works only when IP: is the last field in the event`  

Can you give me an example of a message where the parser doesn't work?  I might be able to help if I can see a tangible message.
